### PR TITLE
fix(navigation): Remove unused gameCode from navigation params

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -14,7 +14,6 @@ import CustomText from './components/CustomText';
 
 type GameData = {
   playerId: number;
-  gameCode: number;
   sessionCode: number;
 };
 
@@ -33,7 +32,6 @@ const HomePage = () => {
     if (data) {
       (navigation as any).navigate('Game', {
         playerId: data.playerId,
-        gameCode: data.gameCode,
         sessionCode: data.sessionCode,
       });
       setOpen(false);


### PR DESCRIPTION
Removes the `gameCode` from the parameters passed to the 'Game' screen.

The `hostGame` function returns a `playerId` and `sessionCode`, but not a `gameCode`. The navigation logic in `HomePage.tsx` was incorrectly trying to pass a `gameCode` property, creating a data mismatch that caused the application to hang after hosting a game.

The `GamePage.tsx` component was also reviewed and does not use the `gameCode` parameter, so no changes were needed there. This change aligns the navigation call with the available data.